### PR TITLE
Feat improved substep sidebar steps

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thefeud/TheFeud.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefeud/TheFeud.java
@@ -447,12 +447,12 @@ public class TheFeud extends BasicQuestHelper
 		//Tell Ali The Operator Poisoned
 		tellAliOperatorPoisoned = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0), "Talk to Ali the Operator and tell him he is dead.");
 
+		killMenaphiteThug = new DetailedQuestStep(this, "Kill the Menaphite Thug. You can safespot him inside the tent by using a chair, if he's not spawned then talk to the Menaphite Leader again.");
+
 		//Step 24
 		//Kill Thug
 		talkToMenaphiteLeader = new NpcStep(this, NpcID.MENAPHITE_LEADER, "Talk to the Menaphite Leader and prepare for a fight against a tough guy. You can safespot him inside the tent by using a chair.");
 		talkToMenaphiteLeader.addSubSteps(killMenaphiteThug);
-
-		killMenaphiteThug = new DetailedQuestStep(this, "Kill the Menaphite Thug. You can safespot him inside the tent by using a chair, if he's not spawned then talk to the Menaphite Leader again.");
 
 		//Step 25
 		//Kill Champion - Talk to Villager

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -139,7 +139,7 @@ public class QuestManager
 			if (selectedQuest.getCurrentStep() != null)
 			{
 				panel.updateStepsTexts();
-				QuestStep currentStep = selectedQuest.getCurrentStep().getSidePanelStep();
+				QuestStep currentStep = selectedQuest.getCurrentStep().getActiveStep();
 				if (currentStep != null && currentStep != lastStep && panel.questActive)
 				{
 					lastStep = currentStep;

--- a/src/main/java/com/questhelper/panel/PanelDetails.java
+++ b/src/main/java/com/questhelper/panel/PanelDetails.java
@@ -29,11 +29,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Collection;
-import java.util.Objects;
+
+import java.util.*;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -131,10 +129,6 @@ public class PanelDetails
 
 	private boolean containsSubStep(QuestStep currentStep, QuestStep check)
 	{
-		if (currentStep.getSubsteps().contains(check) || currentStep == check)
-		{
-			return true;
-		}
-		return currentStep.getSubsteps().stream().anyMatch(step -> containsSubStep(step, check));
+		return currentStep.containsSteps(check, new HashSet<>());
 	}
 }

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -261,7 +261,7 @@ public class QuestOverviewPanel extends JPanel
 		QuestStep currentStep;
 		if (isActive)
 		{
-			currentStep = quest.getCurrentStep().getSidePanelStep();
+			currentStep = quest.getCurrentStep().getActiveStep();
 		}
 		else
 		{

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -35,9 +35,10 @@ import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.HashMap;
 import com.questhelper.steps.QuestStep;
+
+import java.util.HashSet;
 import java.util.List;
 import net.runelite.api.Client;
-import net.runelite.api.Item;
 import net.runelite.client.ui.ColorScheme;
 import javax.annotation.Nullable;
 import javax.swing.*;
@@ -223,7 +224,7 @@ public class QuestStepPanel extends JPanel
 			for (QuestStep step : getSteps())
 			{
 				if (step.getConditionToHide() != null && step.getConditionToHide().check(client)) continue;
-				if (step == newStep || step.getSubsteps().contains(newStep))
+				if (step.containsSteps(newStep, new HashSet<>()))
 				{
 					highlighted = true;
 					updateHighlight(step);
@@ -401,6 +402,6 @@ public class QuestStepPanel extends JPanel
 
 	private QuestStep currentlyActiveQuestSidebarStep()
 	{
-		return questHelperPlugin.getSelectedQuest().getCurrentStep().getSidePanelStep();
+		return questHelperPlugin.getSelectedQuest().getCurrentStep().getActiveStep();
 	}
 }

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -31,12 +31,7 @@ import com.questhelper.requirements.npc.DialogRequirement;
 import com.questhelper.requirements.runelite.RuneliteRequirement;
 import com.questhelper.requirements.conditional.InitializableRequirement;
 import java.awt.Graphics2D;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import lombok.NonNull;
 import lombok.Setter;
@@ -417,18 +412,19 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	}
 
 	@Override
-	public QuestStep getSidePanelStep()
+	public boolean containsSteps(QuestStep questStep, Set<QuestStep> checkedSteps)
 	{
-		if (text != null)
+		if (super.containsSteps(questStep, checkedSteps)) return true;
+
+		Set<QuestStep> stepSet = new HashSet<>(steps.values());
+		stepSet.removeAll(checkedSteps);
+
+		for (QuestStep child : stepSet)
 		{
-			return this;
-		}
-		else if (currentStep != null)
-		{
-			return currentStep.getSidePanelStep();
+			if (child.containsSteps(questStep, checkedSteps)) return true;
 		}
 
-		return this;
+		return false;
 	}
 
 	public Collection<Requirement> getConditions()

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -47,16 +47,13 @@ import com.questhelper.steps.choice.WidgetChoiceSteps;
 import com.questhelper.steps.overlay.IconOverlay;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.SpriteID;
@@ -73,6 +70,7 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
+@Slf4j
 public abstract class QuestStep implements Module
 {
 	@Inject
@@ -522,9 +520,19 @@ public abstract class QuestStep implements Module
 		return this;
 	}
 
-	public QuestStep getSidePanelStep()
+	public boolean containsSteps(QuestStep questStep, Set<QuestStep> checkedSteps)
 	{
-		return getActiveStep();
+		if (checkedSteps.contains(this)) return false;
+		checkedSteps.add(this);
+		return this == questStep || this.getSubsteps().stream().anyMatch((subStep) ->
+		{
+			if (subStep == null)
+			{
+				log.warn("Substep null for " + getText());
+				return false;
+			}
+			return subStep.containsSteps(questStep, checkedSteps);
+		});
 	}
 
 	protected void setupIcon()


### PR DESCRIPTION
This PR is intended to:

1. Make the sidebar substep detection more reliable due to the different levels of depth steps can be
2. Improve the amount of checks performed by the sidebar existence test

For 1, I've grouped the substep check into a boolean returning function within QuestStep. It has a set of steps it uses to ensure we don't get stuck in any loops.

For 2, I've likewise made use of a set for tracking which steps we've already checked.

This hopefully resolves issues with PuzzleWrapper substeps not working correctly in detection.