### PR TITLE
fix: Allow DialogRequirement to check closed dialog box

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/vampyreslayer/VampyreSlayer.java
+++ b/src/main/java/com/questhelper/helpers/quests/vampyreslayer/VampyreSlayer.java
@@ -147,7 +147,7 @@ public class VampyreSlayer extends BasicQuestHelper
 		goUpstairsMorgan = new ObjectStep(this, ObjectID.STAIRS, new WorldPoint(3100, 3267, 0), "Climb the stairs.");
 		getGarlic = new ObjectStep(this, ObjectID.GARLICCUPBOARDOPEN, new WorldPoint(3096, 3270, 1), "Search the cupboard.");
 		getGarlic.addAlternateObjects(ObjectID.GARLICCUPBOARDSHUT);
-		cGetGarlic = new ConditionalStep(this, goUpstairsMorgan, "Get garlic from the cupboard upstairs in Morgan's house.\nYou can tick off this section to skip the garlic acquisition.");
+		cGetGarlic = new ConditionalStep(this, goUpstairsMorgan, "Get garlic from the cupboard upstairs in Morgan's house.\n\nYou can tick off this section in the sidebar to skip the garlic acquisition.");
 		cGetGarlic.addStep(isUpstairsInMorgans, getGarlic);
 
 		talkToHarlow = new NpcStep(this, NpcID.DR_HARLOW, new WorldPoint(3222, 3399, 0), "Talk to Dr. Harlow in the Blue Moon Inn in Varrock.", beerOrTwoCoins);

--- a/src/main/java/com/questhelper/requirements/npc/DialogRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/DialogRequirement.java
@@ -29,6 +29,7 @@ import lombok.Setter;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.util.Text;
 
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ public class DialogRequirement extends SimpleRequirement
 		this.text.addAll(Arrays.asList(text));
 		this.mustBeActive = false;
 	}
+
 	public DialogRequirement(String talkerName, String text, boolean mustBeActive)
 	{
 		this.talkerName = talkerName;
@@ -79,6 +81,18 @@ public class DialogRequirement extends SimpleRequirement
 	public boolean check(Client client)
 	{
 		return hasSeenDialog;
+	}
+
+	public void validateActiveWidget(Client client)
+	{
+		if (!mustBeActive) return;
+
+		var chatModal = client.getWidget(InterfaceID.Chatbox.CHATMODAL);
+
+		if (chatModal == null || chatModal.isHidden())
+		{
+			hasSeenDialog = false;
+		}
 	}
 
 	public void validateCondition(ChatMessage chatMessage)

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -277,7 +277,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 		final var DIALOG_GROUP_IDS = List.of(InterfaceID.CHAT_LEFT, InterfaceID.CHAT_RIGHT, InterfaceID.OBJECTBOX);
 		if (!DIALOG_GROUP_IDS.contains(event.getGroupId())) return;
 
-		clientThread.invokeLater(() -> {
+		clientThread.invokeAtTickEnd(() -> {
 			dialogConditions.forEach(requirement -> requirement.validateActiveWidget(client));
 		});
 	}

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -42,6 +42,7 @@ import lombok.Setter;
 import net.runelite.api.GameState;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.*;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -268,6 +269,17 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 		dialogConditions.forEach(requirement -> requirement.validateCondition(chatMessage));
 
 		handleChildRequirementValidation(step -> step.handleChatMessage(chatMessage, parentDefinedRecursion), parentDefinedRecursion);
+	}
+
+	@Subscribe
+	public void onWidgetClosed(WidgetClosed event)
+	{
+		final var DIALOG_GROUP_IDS = List.of(InterfaceID.CHAT_LEFT, InterfaceID.CHAT_RIGHT, InterfaceID.OBJECTBOX);
+		if (!DIALOG_GROUP_IDS.contains(event.getGroupId())) return;
+
+		clientThread.invokeLater(() -> {
+			dialogConditions.forEach(requirement -> requirement.validateActiveWidget(client));
+		});
 	}
 
 	@Subscribe


### PR DESCRIPTION
Currently a a DialogRequirement which is set to only pass on an active dialog does not have any detection for a closed dialog box, only for a new one added.

This adds closed detection. There's a possibility there could be scenarios which result in the closed check occuring after the new dialog check when a new dialog box appears, and causing it to incorrectly cancel the new dialog's true state, but from testing this doesn't seem to occur.